### PR TITLE
refactored the nonstandardcode.py using black, isort and flake8

### DIFF
--- a/nonstandardcode.py
+++ b/nonstandardcode.py
@@ -1,15 +1,26 @@
-import numpy as np
-import pandas as pd
-import matplotlib as mpl
-import matplotlib.pyplot as plt
 import os
 import tarfile
-from six.moves import urllib
 
+import numpy as np
+import pandas as pd
+from scipy.stats import randint
+from six.moves import urllib
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LinearRegression
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+from sklearn.model_selection import (
+    GridSearchCV,
+    RandomizedSearchCV,
+    StratifiedShuffleSplit,
+    train_test_split,
+)
+from sklearn.tree import DecisionTreeRegressor
 
 DOWNLOAD_ROOT = "https://raw.githubusercontent.com/ageron/handson-ml/master/"
 HOUSING_PATH = os.path.join("datasets", "housing")
 HOUSING_URL = DOWNLOAD_ROOT + "datasets/housing/housing.tgz"
+
 
 def fetch_housing_data(housing_url=HOUSING_URL, housing_path=HOUSING_PATH):
     os.makedirs(housing_path, exist_ok=True)
@@ -19,24 +30,22 @@ def fetch_housing_data(housing_url=HOUSING_URL, housing_path=HOUSING_PATH):
     housing_tgz.extractall(path=housing_path)
     housing_tgz.close()
 
-import pandas as pd
 
 def load_housing_data(housing_path=HOUSING_PATH):
     csv_path = os.path.join(housing_path, "housing.csv")
     return pd.read_csv(csv_path)
 
+
 fetch_housing_data(housing_url=HOUSING_URL, housing_path=HOUSING_PATH)
 housing = load_housing_data(housing_path=HOUSING_PATH)
 
-from sklearn.model_selection import train_test_split
-
 train_set, test_set = train_test_split(housing, test_size=0.2, random_state=42)
 
-housing["income_cat"] = pd.cut(housing["median_income"],
-                               bins=[0., 1.5, 3.0, 4.5, 6., np.inf],
-                               labels=[1, 2, 3, 4, 5])
-
-from sklearn.model_selection import StratifiedShuffleSplit
+housing["income_cat"] = pd.cut(
+    housing["median_income"],
+    bins=[0.0, 1.5, 3.0, 4.5, 6.0, np.inf],
+    labels=[1, 2, 3, 4, 5],
+)
 
 split = StratifiedShuffleSplit(n_splits=1, test_size=0.2, random_state=42)
 for train_index, test_index in split.split(housing, housing["income_cat"]):
@@ -47,15 +56,22 @@ for train_index, test_index in split.split(housing, housing["income_cat"]):
 def income_cat_proportions(data):
     return data["income_cat"].value_counts() / len(data)
 
+
 train_set, test_set = train_test_split(housing, test_size=0.2, random_state=42)
 
-compare_props = pd.DataFrame({
-    "Overall": income_cat_proportions(housing),
-    "Stratified": income_cat_proportions(strat_test_set),
-    "Random": income_cat_proportions(test_set),
-}).sort_index()
-compare_props["Rand. %error"] = 100 * compare_props["Random"] / compare_props["Overall"] - 100
-compare_props["Strat. %error"] = 100 * compare_props["Stratified"] / compare_props["Overall"] - 100
+compare_props = pd.DataFrame(
+    {
+        "Overall": income_cat_proportions(housing),
+        "Stratified": income_cat_proportions(strat_test_set),
+        "Random": income_cat_proportions(test_set),
+    }
+).sort_index()
+compare_props["Rand. %error"] = (
+    100 * compare_props["Random"] / compare_props["Overall"] - 100
+)
+compare_props["Strat. %error"] = (
+    100 * compare_props["Stratified"] / compare_props["Overall"] - 100
+)
 
 for set_ in (strat_train_set, strat_test_set):
     set_.drop("income_cat", axis=1, inplace=True)
@@ -66,48 +82,56 @@ housing.plot(kind="scatter", x="longitude", y="latitude", alpha=0.1)
 
 corr_matrix = housing.corr()
 corr_matrix["median_house_value"].sort_values(ascending=False)
-housing["rooms_per_household"] = housing["total_rooms"]/housing["households"]
-housing["bedrooms_per_room"] = housing["total_bedrooms"]/housing["total_rooms"]
-housing["population_per_household"]=housing["population"]/housing["households"]
+housing["rooms_per_household"] = housing["total_rooms"] / housing["households"]
+housing["bedrooms_per_room"] = (
+    housing["total_bedrooms"] / housing["total_rooms"]
+)
+housing["population_per_household"] = (
+    housing["population"] / housing["households"]
+)
 
-housing = strat_train_set.drop("median_house_value", axis=1) # drop labels for training set
+housing = strat_train_set.drop(
+    "median_house_value", axis=1
+)  # drop labels for training set
 housing_labels = strat_train_set["median_house_value"].copy()
 
-from sklearn.impute import SimpleImputer
 imputer = SimpleImputer(strategy="median")
 
-housing_num = housing.drop('ocean_proximity', axis=1)
+housing_num = housing.drop("ocean_proximity", axis=1)
 
 imputer.fit(housing_num)
 X = imputer.transform(housing_num)
 
-housing_tr = pd.DataFrame(X, columns=housing_num.columns,
-                          index=housing.index)
-housing_tr["rooms_per_household"] = housing_tr["total_rooms"]/housing_tr["households"]
-housing_tr["bedrooms_per_room"] = housing_tr["total_bedrooms"]/housing_tr["total_rooms"]
-housing_tr["population_per_household"]=housing_tr["population"]/housing_tr["households"]
+housing_tr = pd.DataFrame(X, columns=housing_num.columns, index=housing.index)
+housing_tr["rooms_per_household"] = (
+    housing_tr["total_rooms"] / housing_tr["households"]
+)
+housing_tr["bedrooms_per_room"] = (
+    housing_tr["total_bedrooms"] / housing_tr["total_rooms"]
+)
+housing_tr["population_per_household"] = (
+    housing_tr["population"] / housing_tr["households"]
+)
 
-housing_cat = housing[['ocean_proximity']]
-housing_prepared = housing_tr.join(pd.get_dummies(housing_cat, drop_first=True))
+housing_cat = housing[["ocean_proximity"]]
+housing_prepared = housing_tr.join(
+    pd.get_dummies(housing_cat, drop_first=True)
+)
 
-from sklearn.linear_model import LinearRegression
 
 lin_reg = LinearRegression()
 lin_reg.fit(housing_prepared, housing_labels)
 
-from sklearn.metrics import mean_squared_error
+
 housing_predictions = lin_reg.predict(housing_prepared)
 lin_mse = mean_squared_error(housing_labels, housing_predictions)
 lin_rmse = np.sqrt(lin_mse)
 lin_rmse
 
 
-from sklearn.metrics import mean_absolute_error
 lin_mae = mean_absolute_error(housing_labels, housing_predictions)
 lin_mae
 
-
-from sklearn.tree import DecisionTreeRegressor
 
 tree_reg = DecisionTreeRegressor(random_state=42)
 tree_reg.fit(housing_prepared, housing_labels)
@@ -118,37 +142,42 @@ tree_rmse = np.sqrt(tree_mse)
 tree_rmse
 
 
-from sklearn.ensemble import RandomForestRegressor
-from sklearn.model_selection import RandomizedSearchCV
-from scipy.stats import randint
-
 param_distribs = {
-        'n_estimators': randint(low=1, high=200),
-        'max_features': randint(low=1, high=8),
-    }
+    "n_estimators": randint(low=1, high=200),
+    "max_features": randint(low=1, high=8),
+}
 
 forest_reg = RandomForestRegressor(random_state=42)
-rnd_search = RandomizedSearchCV(forest_reg, param_distributions=param_distribs,
-                                n_iter=10, cv=5, scoring='neg_mean_squared_error', random_state=42)
+rnd_search = RandomizedSearchCV(
+    forest_reg,
+    param_distributions=param_distribs,
+    n_iter=10,
+    cv=5,
+    scoring="neg_mean_squared_error",
+    random_state=42,
+)
 rnd_search.fit(housing_prepared, housing_labels)
 cvres = rnd_search.cv_results_
 for mean_score, params in zip(cvres["mean_test_score"], cvres["params"]):
     print(np.sqrt(-mean_score), params)
 
 
-from sklearn.model_selection import GridSearchCV
-
 param_grid = [
     # try 12 (3×4) combinations of hyperparameters
-    {'n_estimators': [3, 10, 30], 'max_features': [2, 4, 6, 8]},
+    {"n_estimators": [3, 10, 30], "max_features": [2, 4, 6, 8]},
     # then try 6 (2×3) combinations with bootstrap set as False
-    {'bootstrap': [False], 'n_estimators': [3, 10], 'max_features': [2, 3, 4]},
-  ]
+    {"bootstrap": [False], "n_estimators": [3, 10], "max_features": [2, 3, 4]},
+]
 
 forest_reg = RandomForestRegressor(random_state=42)
-# train across 5 folds, that's a total of (12+6)*5=90 rounds of training 
-grid_search = GridSearchCV(forest_reg, param_grid, cv=5,
-                           scoring='neg_mean_squared_error', return_train_score=True)
+# train across 5 folds, that's a total of (12+6)*5=90 rounds of training
+grid_search = GridSearchCV(
+    forest_reg,
+    param_grid,
+    cv=5,
+    scoring="neg_mean_squared_error",
+    return_train_score=True,
+)
 grid_search.fit(housing_prepared, housing_labels)
 
 grid_search.best_params_
@@ -165,16 +194,25 @@ final_model = grid_search.best_estimator_
 X_test = strat_test_set.drop("median_house_value", axis=1)
 y_test = strat_test_set["median_house_value"].copy()
 
-X_test_num = X_test.drop('ocean_proximity', axis=1)
+X_test_num = X_test.drop("ocean_proximity", axis=1)
 X_test_prepared = imputer.transform(X_test_num)
-X_test_prepared = pd.DataFrame(X_test_prepared, columns=X_test_num.columns,
-                          index=X_test.index)
-X_test_prepared["rooms_per_household"] = X_test_prepared["total_rooms"]/X_test_prepared["households"]
-X_test_prepared["bedrooms_per_room"] = X_test_prepared["total_bedrooms"]/X_test_prepared["total_rooms"]
-X_test_prepared["population_per_household"]=X_test_prepared["population"]/X_test_prepared["households"]
+X_test_prepared = pd.DataFrame(
+    X_test_prepared, columns=X_test_num.columns, index=X_test.index
+)
+X_test_prepared["rooms_per_household"] = (
+    X_test_prepared["total_rooms"] / X_test_prepared["households"]
+)
+X_test_prepared["bedrooms_per_room"] = (
+    X_test_prepared["total_bedrooms"] / X_test_prepared["total_rooms"]
+)
+X_test_prepared["population_per_household"] = (
+    X_test_prepared["population"] / X_test_prepared["households"]
+)
 
-X_test_cat = X_test[['ocean_proximity']]
-X_test_prepared = X_test_prepared.join(pd.get_dummies(X_test_cat, drop_first=True))
+X_test_cat = X_test[["ocean_proximity"]]
+X_test_prepared = X_test_prepared.join(
+    pd.get_dummies(X_test_cat, drop_first=True)
+)
 
 
 final_predictions = final_model.predict(X_test_prepared)


### PR DESCRIPTION


(mle-dev) prabhu@TIGER01699:~/mle-training$ black nonstandardcode.py
reformatted nonstandardcode.py

All done! ✨ 🍰 ✨
1 file reformatted.
(mle-dev) prabhu@TIGER01699:~/mle-training$ isort nonstandardcode.py
Fixing /home/prabhu/mle-training/nonstandardcode.py
(mle-dev) prabhu@TIGER01699:~/mle-training$ flake8 nonstandardcode.py
nonstandardcode.py:4:1: F401 'matplotlib as mpl' imported but unused
nonstandardcode.py:5:1: F401 'matplotlib.pyplot as plt' imported but unused
nonstandardcode.py:24:1: F811 redefinition of unused 'pd' from line 7
nonstandardcode.py:24:1: E402 module level import not at top of file
nonstandardcode.py:35:1: E402 module level import not at top of file
nonstandardcode.py:45:1: E402 module level import not at top of file
nonstandardcode.py:83:80: E501 line too long (81 > 79 characters)
nonstandardcode.py:84:80: E501 line too long (83 > 79 characters)
nonstandardcode.py:91:1: E402 module level import not at top of file
nonstandardcode.py:101:80: E501 line too long (88 > 79 characters)
nonstandardcode.py:110:80: E501 line too long (80 > 79 characters)
nonstandardcode.py:112:1: E402 module level import not at top of file
nonstandardcode.py:117:1: E402 module level import not at top of file
nonstandardcode.py:125:1: E402 module level import not at top of file
nonstandardcode.py:131:1: E402 module level import not at top of file
nonstandardcode.py:142:1: E402 module level import not at top of file
nonstandardcode.py:143:1: E402 module level import not at top of file
nonstandardcode.py:144:1: E402 module level import not at top of file
nonstandardcode.py:166:1: E402 module level import not at top of file
nonstandardcode.py:216:80: E501 line too long (83 > 79 characters)
(mle-dev) prabhu@TIGER01699:~/mle-training$ flake8 nonstandardcode.py